### PR TITLE
fix: Documents loaded in background no longer folds imports in active text editor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
       }
 
       // Trigger folding command.
-      changeFoldingOfImportLines(FoldActions.FOLD, importsBlock);
+      changeFoldingOfImportLines(document, FoldActions.FOLD, importsBlock);
     }
   );
 
@@ -47,7 +47,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
       }
 
       // Trigger folding command.
-      changeFoldingOfImportLines(FoldActions.UNFOLD, importsBlock);
+      changeFoldingOfImportLines(document, FoldActions.UNFOLD, importsBlock);
     }
   );
 
@@ -61,7 +61,7 @@ export function activate(extensionContext: vscode.ExtensionContext) {
       return;
     }
 
-    changeFoldingOfImportLines(FoldActions.FOLD, importsBlock);
+    changeFoldingOfImportLines(document, FoldActions.FOLD, importsBlock);
   });
 }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -75,16 +75,22 @@ export function findImportsBlock(
 }
 
 export function changeFoldingOfImportLines(
+  document: vscode.TextDocument,
   action: FoldActions,
   block: ImportsBlock
 ) {
-  const command = action === FoldActions.FOLD ? 'editor.fold' : 'editor.unfold';
-  logger(`Running ${command} at line ${block.start}`);
-  // Change folding at the line number.
-  vscode.commands.executeCommand(command, {
-    levels: 1,
-    selectionLines: [block.start],
-  });
+  setImmediate(() => {
+    const command = action === FoldActions.FOLD ? 'editor.fold' : 'editor.unfold';
+    if (vscode.window.activeTextEditor?.document !== document) {
+      return;
+    }
+    logger(`Running ${command} at line ${block.start}`);
+    // Change folding at the line number.
+    vscode.commands.executeCommand(command, {
+      levels: 1,
+      selectionLines: [block.start],
+    });
+  })
 }
 
 export function shouldAutoFoldImports(block: ImportsBlock | undefined) {


### PR DESCRIPTION
Fixes #1. Peek commands trigger `onDidOpenTextDocument` event too but loads the document in the background. Problem is `editor.fold` runs in active text editor.

Without `setImmediate` `activeTextEditor` is `undefined`.